### PR TITLE
Properly normalize repository name

### DIFF
--- a/clean_ghcr.py
+++ b/clean_ghcr.py
@@ -60,7 +60,7 @@ def get_list_packages(owner, repo_name, owner_type, package_name):
     if repo_name:
         all_org_pkg = [
             pkg for pkg in all_org_pkg
-            if pkg.get("repository") and pkg["repository"]["name"] == repo_name
+            if pkg.get("repository") and pkg["repository"]["name"].lower() == repo_name
         ]
     if package_name:
         all_org_pkg = [


### PR DESCRIPTION
GitHub uses the proper capitalization in that name field. The repo_name is always lowercase. So this check can never succeed if the repo name has any uppercase letters.