### PR TITLE
Avoid listing org packages where job token doesn't have access

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ delete all / untagged ghcr containers in a repository
 - name: Delete all containers from package without tags
     uses: Chizkiyahu/delete-untagged-ghcr-action@v2
     with:
-        token: ${{ secrets.PAT_TOKEN }}
+        token: ${{ github.token }}
         repository_owner: ${{ github.repository_owner }}
         repository: ${{ github.repository }}
         package_name: the-package-name
@@ -145,12 +145,12 @@ delete all / untagged ghcr containers in a repository
   uses: docker/login-action@v2
   with:
     registry: ghcr.io
-    username: ${{ github.actor }}
-    password: ${{ secrets.PAT_TOKEN }}
+    username: ${{ github.repository_owner }}
+    password: ${{ github.token }}
 - name: Delete all containers from package without tags
     uses: Chizkiyahu/delete-untagged-ghcr-action@v2
     with:
-        token: ${{ secrets.PAT_TOKEN }}
+        token: ${{ github.token }}
         repository_owner: ${{ github.repository_owner }}
         repository: ${{ github.repository }}
         package_name: the-package-name
@@ -164,7 +164,7 @@ delete all / untagged ghcr containers in a repository
 - name: Delete all containers from package
     uses: Chizkiyahu/delete-untagged-ghcr-action@v2
     with:
-        token: ${{ secrets.PAT_TOKEN }}
+        token: ${{ github.token }}
         repository_owner: ${{ github.repository_owner }}
         repository: ${{ github.repository }}
         package_name: the-package-name

--- a/clean_ghcr.py
+++ b/clean_ghcr.py
@@ -55,16 +55,18 @@ def get_req(path, params=None):
 
 
 def get_list_packages(owner, repo_name, owner_type, package_name):
+    if package_name:
+        return [{
+            "name": package_name,
+            "url": f"/{owner_type}s/{owner}/packages/container/{package_name}",
+        }]
+
     all_org_pkg = get_req(
         f"/{owner_type}s/{owner}/packages?package_type=container")
     if repo_name:
         all_org_pkg = [
             pkg for pkg in all_org_pkg if pkg.get("repository")
             and pkg["repository"]["name"].lower() == repo_name
-        ]
-    if package_name:
-        all_org_pkg = [
-            pkg for pkg in all_org_pkg if pkg["name"] == package_name
         ]
     return all_org_pkg
 


### PR DESCRIPTION
This allows using the job token directly.

Example workflow:
```yaml
permissions:
  packages: write

jobs:
  cleanup-images:
    runs-on: ubuntu-22.04
    steps:
      - name: Cleanup untagged images
        uses: mering/delete-untagged-ghcr-action@main
        with:
          token: ${{ github.token }}
          repository_owner: ${{ github.repository_owner }}
          repository: ${{ github.repository }}
          package_name: IMAGE_NAME
          untagged_only: true
          owner_type: org

```