### PR TITLE
Avoid listing org packages where job token doesn't have access

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,16 +25,16 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: lower case repository
-        id: lower_case_repository
+      - name: lower case repository_owner
+        id: lower_case_repository_owner
         uses: ASzc/change-string-case-action@v6
         with:
-          string: ${{ github.repository }}
+          string: ${{ github.repository_owner }}
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
           file: ./CICD/Dockerfile_temp
-          tags: ghcr.io/${{ steps.lower_case_repository.outputs.lowercase }}/${{ matrix.type }}:${{ matrix.i }}
+          tags: ghcr.io/${{ steps.lower_case_repository_owner.outputs.lowercase }}/${{ matrix.type }}:${{ matrix.i }}
           build-args: |
             I=${{ matrix.i }}
           push: true
@@ -58,16 +58,16 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: lower case repository
-        id: lower_case_repository
+      - name: lower case repository_owner
+        id: lower_case_repository_owner
         uses: ASzc/change-string-case-action@v6
         with:
-          string: ${{ github.repository }}
+          string: ${{ github.repository_owner }}
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
           file: ./CICD/Dockerfile_temp
-          tags: ghcr.io/${{ steps.lower_case_repository.outputs.lowercase }}/${{ matrix.type }}:${{ matrix.i }}
+          tags: ghcr.io/${{ steps.lower_case_repository_owner.outputs.lowercase }}/${{ matrix.type }}:${{ matrix.i }}
           build-args: |
             I=${{ matrix.i }}
           push: true
@@ -123,7 +123,7 @@ jobs:
           token: ${{ secrets.PAT_TOKEN }}
           repository_owner: ${{ github.repository_owner }}
           repository: ${{ github.repository }}
-          package_name: ${{ github.repository }}/p1
+          package_name: p1
           untagged_only: false
           owner_type: user
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,9 @@ on:
   workflow_dispatch:
   
 concurrency: testing
+permissions:
+  contents: read
+  packages: write
 jobs:
   add_temp_pkgs1:
     name: Add temporary packages for testing
@@ -23,7 +26,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
+          username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: lower case repository_owner
         id: lower_case_repository_owner
@@ -56,7 +59,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
+          username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: lower case repository_owner
         id: lower_case_repository_owner
@@ -82,12 +85,12 @@ jobs:
       - uses: actions/checkout@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Login to GitHub Container Registry with PAT_TOKEN
+      - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.PAT_TOKEN }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - uses: ./
         with:
           token: ${{ secrets.PAT_TOKEN }}
@@ -120,7 +123,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./
         with:
-          token: ${{ secrets.PAT_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           repository_owner: ${{ github.repository_owner }}
           repository: ${{ github.repository }}
           package_name: p1

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ delete all / untagged ghcr containers in a repository
 - name: Delete all containers from package without tags
     uses: Chizkiyahu/delete-untagged-ghcr-action@v2
     with:
-        token: ${{ secrets.PAT_TOKEN }}
+        token: ${{ github.token }}
         repository_owner: ${{ github.repository_owner }}
         repository: ${{ github.repository }}
         package_name: the-package-name
@@ -145,12 +145,12 @@ delete all / untagged ghcr containers in a repository
   uses: docker/login-action@v2
   with:
     registry: ghcr.io
-    username: ${{ github.actor }}
-    password: ${{ secrets.PAT_TOKEN }}
+    username: ${{ github.repository_owner }}
+    password: ${{ github.token }}
 - name: Delete all containers from package without tags
     uses: Chizkiyahu/delete-untagged-ghcr-action@v2
     with:
-        token: ${{ secrets.PAT_TOKEN }}
+        token: ${{ github.token }}
         repository_owner: ${{ github.repository_owner }}
         repository: ${{ github.repository }}
         package_name: the-package-name
@@ -164,7 +164,7 @@ delete all / untagged ghcr containers in a repository
 - name: Delete all containers from package
     uses: Chizkiyahu/delete-untagged-ghcr-action@v2
     with:
-        token: ${{ secrets.PAT_TOKEN }}
+        token: ${{ github.token }}
         repository_owner: ${{ github.repository_owner }}
         repository: ${{ github.repository }}
         package_name: the-package-name

--- a/clean_ghcr.py
+++ b/clean_ghcr.py
@@ -38,19 +38,18 @@ def get_req(path, params=None):
     if "per_page" not in params:
         params["per_page"] = PER_PAGE
     url = get_url(path)
-    another_page = True
     result = []
-    while another_page:
+    while True:
         response = requests.get(url, headers=get_base_headers(), params=params)
         if not response.ok:
             raise Exception(response.text)
         result.extend(response.json())
-        if "next" in response.links:
-            url = response.links["next"]["url"]
-            if "page" in params:
-                del params["page"]
-        else:
-            another_page = False
+
+        if "next" not in response.links:
+            break
+        url = response.links["next"]["url"]
+        if "page" in params:
+            del params["page"]
     return result
 
 

--- a/clean_ghcr.py
+++ b/clean_ghcr.py
@@ -216,10 +216,6 @@ def get_args():
                 f"Mismatch in repository:{args.repository} and repository_owner:{args.repository_owner}"
             )
         args.repository = repository
-    if args.package_name and args.package_name.count("/") == 2:
-        _, repo_name, package_name = args.package_name.split("/")
-        package_name = f"{repo_name}/{package_name}"
-        args.package_name = package_name
     args.repository = args.repository.lower()
     args.repository_owner = args.repository_owner.lower()
     args.package_name = args.package_name.lower()

--- a/clean_ghcr.py
+++ b/clean_ghcr.py
@@ -54,16 +54,22 @@ def get_req(path, params=None):
 
 
 def get_list_packages(owner, repo_name, owner_type, package_name):
+    if package_name:
+        url = get_url(
+            f"/{owner_type}s/{owner}/packages/container/{package_name}")
+        response = requests.get(url, headers=get_base_headers())
+        if not response.ok:
+            if response.status_code == 404:
+                return []
+            raise Exception(response.text)
+        return [response.json()]
+
     all_org_pkg = get_req(
         f"/{owner_type}s/{owner}/packages?package_type=container")
     if repo_name:
         all_org_pkg = [
             pkg for pkg in all_org_pkg if pkg.get("repository")
             and pkg["repository"]["name"].lower() == repo_name
-        ]
-    if package_name:
-        all_org_pkg = [
-            pkg for pkg in all_org_pkg if pkg["name"] == package_name
         ]
     return all_org_pkg
 


### PR DESCRIPTION
Follow-up on #23 but now including a fix to taking the special case into account where `package_name` doesn't exist.

Unfortunately, I can't run the tests as I don't have access to create the packages for testing (403 permission denied).

---

This allows using the job token directly.

Example workflow:
```yaml
permissions:
  packages: write

jobs:
  cleanup-images:
    runs-on: ubuntu-22.04
    steps:
      - name: Cleanup untagged images
        uses: mering/delete-untagged-ghcr-action@main
        with:
          token: ${{ github.token }}
          repository_owner: ${{ github.repository_owner }}
          repository: ${{ github.repository }}
          package_name: IMAGE_NAME
          untagged_only: true
          owner_type: org

```