### PR TITLE
Fix package name handling

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,16 +25,16 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: lower case repository
-        id: lower_case_repository
+      - name: lower case repository_owner
+        id: lower_case_repository_owner
         uses: ASzc/change-string-case-action@v6
         with:
-          string: ${{ github.repository }}
+          string: ${{ github.repository_owner }}
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
           file: ./CICD/Dockerfile_temp
-          tags: ghcr.io/${{ steps.lower_case_repository.outputs.lowercase }}/${{ matrix.type }}:${{ matrix.i }}
+          tags: ghcr.io/${{ steps.lower_case_repository_owner.outputs.lowercase }}/${{ matrix.type }}:${{ matrix.i }}
           build-args: |
             I=${{ matrix.i }}
           push: true
@@ -58,16 +58,16 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: lower case repository
-        id: lower_case_repository
+      - name: lower case repository_owner
+        id: lower_case_repository_owner
         uses: ASzc/change-string-case-action@v6
         with:
-          string: ${{ github.repository }}
+          string: ${{ github.repository_owner }}
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
           file: ./CICD/Dockerfile_temp
-          tags: ghcr.io/${{ steps.lower_case_repository.outputs.lowercase }}/${{ matrix.type }}:${{ matrix.i }}
+          tags: ghcr.io/${{ steps.lower_case_repository_owner.outputs.lowercase }}/${{ matrix.type }}:${{ matrix.i }}
           build-args: |
             I=${{ matrix.i }}
           push: true
@@ -123,7 +123,7 @@ jobs:
           token: ${{ secrets.PAT_TOKEN }}
           repository_owner: ${{ github.repository_owner }}
           repository: ${{ github.repository }}
-          package_name: ${{ github.repository }}/p1
+          package_name: p1
           untagged_only: false
           owner_type: user
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ delete all / untagged ghcr containers in a repository
       token: ${{ secrets.PAT_TOKEN }}
       repository_owner: ${{ github.repository_owner }}
       repository: ${{ github.repository }}
-      package_name: the-package-name # full name includes the repository name if is connected to repository
+      package_name: the-package-name
       untagged_only: true
       owner_type: org # or user
 ```
@@ -153,7 +153,7 @@ delete all / untagged ghcr containers in a repository
       token: ${{ secrets.PAT_TOKEN }}
       repository_owner: ${{ github.repository_owner }}
       repository: ${{ github.repository }}
-      package_name: the-package-name  # full name includes the repository name if is connected to repository
+      package_name: the-package-name
       untagged_only: true
       owner_type: org # or user
       except_untagged_multiplatform: true
@@ -167,7 +167,7 @@ delete all / untagged ghcr containers in a repository
       token: ${{ secrets.PAT_TOKEN }}
       repository_owner: ${{ github.repository_owner }}
       repository: ${{ github.repository }}
-      package_name: the-package-name  # full name includes the repository name if is connected to repository
+      package_name: the-package-name
       untagged_only: false
       owner_type: org # or user
 ```

--- a/clean_ghcr.py
+++ b/clean_ghcr.py
@@ -223,10 +223,6 @@ def get_args():
                 f"Mismatch in repository:{args.repository} and repository_owner:{args.repository_owner}"
             )
         args.repository = repository
-    if args.package_name and args.package_name.count("/") == 2:
-        _, repo_name, package_name = args.package_name.split("/")
-        package_name = f"{repo_name}/{package_name}"
-        args.package_name = package_name
     args.repository = args.repository.lower()
     args.repository_owner = args.repository_owner.lower()
     args.package_name = args.package_name.lower()


### PR DESCRIPTION
Package names can have an arbitrary number of forward slashes (`/`). So if my package is called `a/b/c` and contains exactly two forward slashes, the `a` is erroneously stripped and in turn the image `a/b/c` is not deleted, or even worse another image `b/c` is deleted if it existed!