### PR TITLE
Update setup-python to v5

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -18,7 +18,7 @@ jobs:
         run: |
           echo "GITHUB_SHA_SHORT=$(echo ${{ github.sha }} | cut -c 1-6)" >> $GITHUB_ENV
           echo ${{ env.GITHUB_SHA_SHORT }}
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.9'
       - run: pip install yapf

--- a/action.yml
+++ b/action.yml
@@ -40,7 +40,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.9'
     - name: Install Python dependencies


### PR DESCRIPTION
I've been using your action (thanks for that!) and noticed that github actions throws an error due to your dependencies.

```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/setup-python@v4. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```

___

This PR updated `setup-python` from v4 to v5. There should be no additional changes, as upgrading node is the only addition in v5 (see https://github.com/actions/setup-python/releases)
