### PR TITLE
update documentation and defaults for repository and except_untagged_multiplatform

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,12 @@ delete all / untagged ghcr containers in a repository
     # Default: true
     # choices: true, false
     untagged_only: true
-    # Except untagged multiplatform packages from deletion
+    # Exclude untagged multiplatform packages from deletion
+    # Manifests are usually such packages so they should be excluded
     # only for untagged_only=true
+    # Default: true
     # needs docker installed
-    except_untagged_multiplatform: false
+    except_untagged_multiplatform: true
     # the owner type
     # required: true
     # choices: org, user

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,7 @@ inputs:
     required: true
   repository:
     description: 'Delete only from repository name'
+    default: ${{ github.repository }}
     required: false
   package_name:
     description: 'Delete only from comma separated package names'
@@ -26,8 +27,8 @@ inputs:
       description: 'Delete only package versions without tag'
       default: true
   except_untagged_multiplatform:
-    description: 'Except untagged multiplatform packages from deletion (only for --untagged_only)'
-    default: false
+    description: 'Exclude untagged multiplatform packages from deletion (only for --untagged_only)'
+    default: true
   owner_type:
       description : "Owner type (org or user)"
       required: true


### PR DESCRIPTION
- Set default for `repository` option to `${{ github.repository }}`
- Set default for `except_untagged_multiplatform` to `true` in order to avoid deleting manifests
- Update docs where applicable